### PR TITLE
fixed library dependencies. Now linking to adafruit's tags instead of platform.io packages

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,16 +27,19 @@ check_tool = cppcheck, clangtidy
 data_dir = data
 framework = arduino
 lib_deps =
-    Adafruit MCP23017 Arduino Library@1.0.3
+    # Adafruit MCP23017 Arduino Library@1.0.3
+    https://github.com/adafruit/Adafruit-MCP23017-Arduino-Library#1.0.3
     ArduinoJson@6.10.1
     ivanseidel/LinkedList
-    Adafruit PWM Servo Driver Library@1.0.4
+    https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library#1.0.4
+    # Adafruit PWM Servo Driver Library@1.0.4
     Adafruit SSD1306 Wemos Mini OLED
-    Adafruit GFX Library@1.5.7
+    https://github.com/adafruit/Adafruit-GFX-Library#1.5.7
+    # Adafruit GFX Library@1.5.7
     LiquidCrystal
     https://github.com/littleyoda/LCDIC2
     https://github.com/PetrOsipov/ArduinoPortExtender.git
-#    https://github.com/greiman/SSD1306Ascii
+    # https://github.com/greiman/SSD1306Ascii
     
 upload_port = /dev/ttyUSB*
 #upload_speed = 921600


### PR DESCRIPTION
Unfortunately, the project could no longer be compiled because the dependencies were no longer available on platform.io. I have re-linked them using the Adafruit GitHub tags. Now everything is working correctly again :)